### PR TITLE
Remove hirak/prestissimo from Render deployment script

### DIFF
--- a/scripts/00-laravel-deploy.sh
+++ b/scripts/00-laravel-deploy.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 echo "Running composer"
-composer global require hirak/prestissimo
 composer install --no-dev --working-dir=/var/www/html
+
+echo "generating application key..."
+php artisan key:generate --show
 
 echo "Caching config..."
 php artisan config:cache
@@ -10,4 +12,5 @@ echo "Caching routes..."
 php artisan route:cache
 
 echo "Running migrations..."
-php artisan migrate:fresh --force && php artisan db:seed --force
+php artisan migrate:fresh --force
+php artisan db:seed --force


### PR DESCRIPTION
## Summary 
- **Chores**
	- Removed hirak/prestissimo from the deployment script for Render, since it's used only for Composer 1