### PR TITLE
Fix Program component boolean parameters

### DIFF
--- a/app/View/Components/Program.php
+++ b/app/View/Components/Program.php
@@ -2,28 +2,27 @@
 
 namespace App\View\Components;
 
+use App\Models\Program as ProgramModel;
 use Closure;
 use Illuminate\Contracts\View\View;
 use Illuminate\View\Component;
 
 class Program extends Component
 {
-    public $program;
+    public ProgramModel $program;
 
-    public $repeatInstitute;
+    public bool $repeatInstitute;
 
-    public $showCourses;
+    public bool $showCourses;
 
     /**
      * Create a new component instance.
-     *
-     * @return void
      */
-    public function __construct($program, $repeatInstitute, $showCourses)
+    public function __construct(ProgramModel $program, ?bool $repeatInstitute = false, ?bool $showCourses = false)
     {
         $this->program = $program;
-        $this->repeatInstitute = $repeatInstitute == 'true';
-        $this->showCourses = $showCourses == 'true';
+        $this->repeatInstitute = $repeatInstitute ?? false;
+        $this->showCourses = $showCourses ?? false;
     }
 
     /**

--- a/tests/Unit/View/Components/ProgramTest.php
+++ b/tests/Unit/View/Components/ProgramTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Unit\View\Components;
+
+use App\Models\Program as ProgramModel;
+use App\View\Components\Program as ProgramComponent;
+use PHPUnit\Framework\TestCase;
+
+class ProgramTest extends TestCase
+{
+    public function test_program_component_accepts_boolean_options(): void
+    {
+        $program = new ProgramModel;
+
+        $component = new ProgramComponent($program, true, false);
+
+        $this->assertSame($program, $component->program);
+        $this->assertTrue($component->repeatInstitute);
+        $this->assertFalse($component->showCourses);
+    }
+
+    public function test_program_component_defaults_options_to_false(): void
+    {
+        $component = new ProgramComponent(new ProgramModel);
+
+        $this->assertFalse($component->repeatInstitute);
+        $this->assertFalse($component->showCourses);
+    }
+
+    public function test_program_component_treats_null_options_as_false(): void
+    {
+        $component = new ProgramComponent(new ProgramModel, null, null);
+
+        $this->assertFalse($component->repeatInstitute);
+        $this->assertFalse($component->showCourses);
+    }
+}


### PR DESCRIPTION
## Summary
- type the Program Blade component constructor with the Program model and nullable boolean flags
- default repeatInstitute and showCourses to false without string comparisons
- add unit coverage for explicit booleans, omitted options, and null options

Closes #12

## Verification
- php artisan test
- lando pint
- lando larastan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added unit tests to verify proper handling of component options and default behavior

* **Refactor**
  * Enhanced type safety and robustness of component property declarations and initialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->